### PR TITLE
[QA] Updates Active Support and Model Versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source :rubygems
 
 gem 'wasabi', :git => 'git://github.com/skiz/wasabi.git'
 
-#gemspec
+gemspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source :rubygems
 
 gem 'wasabi', :git => 'git://github.com/skiz/wasabi.git'
 
-gemspec
+#gemspec
 

--- a/zuora.gemspec
+++ b/zuora.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = [ "README.md" ]
 
   s.add_runtime_dependency(%q<savon>, ["0.9.8"])
-  s.add_runtime_dependency(%q<activesupport>, ["3.2.8"])
-  s.add_runtime_dependency(%q<activemodel>, ["3.2.8"])
+  s.add_runtime_dependency(%q<activesupport>, ["3.2.10"])
+  s.add_runtime_dependency(%q<activemodel>, ["3.2.10"])
   s.add_runtime_dependency(%q<libxml4r>, ['0.2.6'])
 
   s.add_development_dependency(%q<rake>, ["0.8.7"])

--- a/zuora.gemspec
+++ b/zuora.gemspec
@@ -17,18 +17,18 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.extra_rdoc_files = [ "README.md" ]
 
-  s.add_runtime_dependency(%q<savon>, ["~> 0.9.8"])
-  s.add_runtime_dependency(%q<activesupport>, [">= 3.0.0", "< 4.0.0"])
-  s.add_runtime_dependency(%q<activemodel>, [">= 3.0.0", "< 4.0.0"])
-  s.add_runtime_dependency(%q<libxml4r>, ['~> 0.2.6'])
+  s.add_runtime_dependency(%q<savon>, ["0.9.8"])
+  s.add_runtime_dependency(%q<activesupport>, ["3.2.8"])
+  s.add_runtime_dependency(%q<activemodel>, ["3.2.8"])
+  s.add_runtime_dependency(%q<libxml4r>, ['0.2.6'])
 
-  s.add_development_dependency(%q<rake>, ["~> 0.8.7"])
-  s.add_development_dependency(%q<guard-rspec>, ["~> 0.6.0"])
-  s.add_development_dependency(%q<artifice>, ["~> 0.6.0"])
-  s.add_development_dependency(%q<yard>, ["~> 0.7.5"])
-  s.add_development_dependency(%q<rspec>, ["~> 2.8.0"])
-  s.add_development_dependency(%q<redcarpet>, ["~> 2.1.0"])
-  s.add_development_dependency(%q<factory_girl>, ["~> 2.6.4"])
-  s.add_development_dependency(%q<appraisal>, ["~> 0.4.1"])
-  s.add_development_dependency(%q<sqlite3>, ["~> 1.3.0"])
+  s.add_development_dependency(%q<rake>, ["0.9.2.2"])
+  s.add_development_dependency(%q<guard-rspec>, ["0.6.0"])
+  s.add_development_dependency(%q<artifice>, ["0.6.0"])
+  s.add_development_dependency(%q<yard>, ["0.7.5"])
+  s.add_development_dependency(%q<rspec>, ["2.11.0"])
+  s.add_development_dependency(%q<redcarpet>, ["2.1.0"])
+  s.add_development_dependency(%q<factory_girl>, ["2.6.4"])
+  s.add_development_dependency(%q<appraisal>, ["0.4.1"])
+  s.add_development_dependency(%q<sqlite3>, ["1.3.6"])
 end


### PR DESCRIPTION
### Overview

In order to support upgrading to Rails 3.2.10 we need to update the dependency versions in this gem.
### Testing

Basic regression testing of any Zuora integration should suffice. 
